### PR TITLE
Changed classifier to silva

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -17,7 +17,7 @@ denoise:
     n_threads: 6
 
 taxonomy:
-    classifier_fp: "/home/danielsg/16S_QIIME2/QIIME2_data/gg-13-8-99-nb-classifier.qza"
+    classifier_fp: "/mnt/isilon/microbiome/analysis/biodata/silva/silva_132/silva-132-99-nb-classifier.qza"
 
 diversity:
     sampling_depth: 1000

--- a/run_snakemake.bash
+++ b/run_snakemake.bash
@@ -31,4 +31,4 @@ snakemake \
     --notemp \
     --printshellcmds \
     --cluster \
-    "sbatch --mem=10G -t 12:00:00 -n 4 --export=ALL --no-requeue"
+    "sbatch --mem=32G -t 24:00:00 -n 4 --export=ALL --no-requeue"


### PR DESCRIPTION
2019.7 had silva 132 available. 
There is a new version of silva 138 available to use. Might consider updating the QIIME version as well together with silva